### PR TITLE
Add MCQ and time limit fields to admin passage creator

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -306,10 +306,25 @@
                         
                         <div class="form-group">
                             <label for="passage-content" class="form-label">Content *</label>
-                            <textarea id="passage-content" class="form-textarea" required 
+                            <textarea id="passage-content" class="form-textarea" required
                                 placeholder="Enter the passage content here..."></textarea>
                         </div>
-                        
+
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="passage-time" class="form-label">Time Limit (minutes)</label>
+                                <input type="number" id="passage-time" class="form-input" min="1" max="60" value="10" required>
+                            </div>
+                        </div>
+
+                        <div class="questions-section">
+                            <div class="questions-header">
+                                <h3>Questions</h3>
+                                <button type="button" class="btn btn-primary btn-sm" onclick="addQuestion()">Add Question</button>
+                            </div>
+                            <div id="questions-container"></div>
+                        </div>
+
                         <div class="form-group">
                             <div class="checkbox-group">
                                 <input type="checkbox" id="passage-published">
@@ -413,6 +428,7 @@
 
         let currentPassages = [];
         let editingPassageId = null;
+        let questionCount = 0;
 
         // Check admin access
         document.addEventListener('DOMContentLoaded', function() {
@@ -495,6 +511,9 @@
                             <div style="font-size: 0.8rem; color: #64748b; margin-top: 0.25rem;">
                                 ${passage.content.substring(0, 100)}...
                             </div>
+                            <div style="font-size: 0.8rem; color: #64748b; margin-top: 0.25rem;">
+                                ${(passage.questions ? passage.questions.length : 0)} questions • ${passage.timeLimit || 0} min
+                            </div>
                         </td>
                         <td>${passage.subject}</td>
                         <td>
@@ -522,6 +541,99 @@
                 `;
             }).join('');
         }
+        function addQuestion(question = {}) {
+            questionCount++;
+            const qId = questionCount;
+            const container = document.getElementById('questions-container');
+
+            const div = document.createElement('div');
+            div.className = 'question-item';
+            div.dataset.questionId = qId;
+            div.innerHTML = `
+                <div class="question-header">
+                    <span class="question-number">Question ${qId}</span>
+                    <div class="question-controls">
+                        <button type="button" class="btn btn-icon btn-secondary" onclick="moveQuestionUp(${qId})" title="Move Up">↑</button>
+                        <button type="button" class="btn btn-icon btn-secondary" onclick="moveQuestionDown(${qId})" title="Move Down">↓</button>
+                        <button type="button" class="btn btn-icon btn-warning" onclick="removeQuestion(${qId})" title="Remove">×</button>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">Question Text *</label>
+                    <textarea class="form-input question-text" rows="2" required>${question.q || ''}</textarea>
+                </div>
+                <div class="options-container">
+                    ${['A','B','C','D'].map((letter,index) => `
+                        <div class="option-group">
+                            <label class="form-label">${letter}:</label>
+                            <input type="text" class="option-input" value="${question.options ? question.options[index] || '' : ''}" required>
+                            <label class="correct-marker">
+                                <input type="radio" name="correct-${qId}" value="${index}" ${question.answerIndex === index ? 'checked' : ''}>
+                                Correct
+                            </label>
+                        </div>
+                    `).join('')}
+                </div>
+            `;
+            container.appendChild(div);
+        }
+
+        function removeQuestion(id) {
+            const el = document.querySelector(`[data-question-id="${id}"]`);
+            if (el) {
+                el.remove();
+                renumberQuestions();
+            }
+        }
+
+        function moveQuestionUp(id) {
+            const el = document.querySelector(`[data-question-id="${id}"]`);
+            const prev = el?.previousElementSibling;
+            if (el && prev) {
+                el.parentNode.insertBefore(el, prev);
+                renumberQuestions();
+            }
+        }
+
+        function moveQuestionDown(id) {
+            const el = document.querySelector(`[data-question-id="${id}"]`);
+            const next = el?.nextElementSibling;
+            if (el && next) {
+                el.parentNode.insertBefore(next, el);
+                renumberQuestions();
+            }
+        }
+
+        function renumberQuestions() {
+            const items = document.querySelectorAll('.question-item');
+            items.forEach((el, index) => {
+                const num = index + 1;
+                el.querySelector('.question-number').textContent = `Question ${num}`;
+                el.dataset.questionId = num;
+                el.querySelectorAll('input[type="radio"]').forEach(r => r.name = `correct-${num}`);
+            });
+            questionCount = items.length;
+        }
+
+        function collectQuestions() {
+            const questions = [];
+            const items = document.querySelectorAll('.question-item');
+            items.forEach(item => {
+                const qText = item.querySelector('.question-text').value.trim();
+                const options = Array.from(item.querySelectorAll('.option-input')).map(i => i.value.trim());
+                const correct = item.querySelector('input[type="radio"]:checked');
+                const answerIndex = correct ? parseInt(correct.value) : -1;
+                if (qText && options.every(o => o) && answerIndex >= 0) {
+                    questions.push({ q: qText, options, answerIndex });
+                }
+            });
+            return questions;
+        }
+
+        window.addQuestion = addQuestion;
+        window.removeQuestion = removeQuestion;
+        window.moveQuestionUp = moveQuestionUp;
+        window.moveQuestionDown = moveQuestionDown;
 
         // Show create passage form
         window.showCreatePassageForm = function() {
@@ -530,12 +642,18 @@
             document.getElementById('passage-form').reset();
             document.getElementById('passage-form-container').style.display = 'block';
             document.getElementById('passage-title').focus();
+            document.getElementById('passage-time').value = 10;
+            document.getElementById('questions-container').innerHTML = '';
+            questionCount = 0;
+            addQuestion();
         };
 
         // Hide passage form
         window.hidePassageForm = function() {
             document.getElementById('passage-form-container').style.display = 'none';
             editingPassageId = null;
+            document.getElementById('questions-container').innerHTML = '';
+            questionCount = 0;
         };
 
         // Edit passage
@@ -551,7 +669,16 @@
             document.getElementById('passage-difficulty').value = passage.difficulty;
             document.getElementById('passage-content').value = passage.content;
             document.getElementById('passage-published').checked = passage.isPublished;
-            
+            document.getElementById('passage-time').value = passage.timeLimit || 10;
+            const qContainer = document.getElementById('questions-container');
+            qContainer.innerHTML = '';
+            questionCount = 0;
+            if (passage.questions && passage.questions.length) {
+                passage.questions.forEach(q => addQuestion(q));
+            } else {
+                addQuestion();
+            }
+
             document.getElementById('passage-form-container').style.display = 'block';
             document.getElementById('passage-title').focus();
         };
@@ -598,11 +725,19 @@
         document.getElementById('passage-form').addEventListener('submit', async function(e) {
             e.preventDefault();
 
+            const questions = collectQuestions();
+            if (questions.length === 0) {
+                showToast('Add at least one question', 'error');
+                return;
+            }
+
             const formData = {
                 title: document.getElementById('passage-title').value.trim(),
                 subject: document.getElementById('passage-subject').value,
                 difficulty: document.getElementById('passage-difficulty').value,
                 content: document.getElementById('passage-content').value.trim(),
+                timeLimit: parseInt(document.getElementById('passage-time').value) || 0,
+                questions: questions,
                 isPublished: document.getElementById('passage-published').checked
             };
 

--- a/assets/js/attempts.js
+++ b/assets/js/attempts.js
@@ -6,15 +6,13 @@
 import { db } from './firebase.js';
 import { authManager } from './auth.js';
 import { 
-  collection, 
-  doc, 
-  addDoc, 
-  getDocs, 
-  query, 
-  where, 
-  orderBy, 
-  limit,
-  serverTimestamp 
+  collection,
+  doc,
+  addDoc,
+  getDocs,
+  query,
+  where,
+  serverTimestamp
 } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js';
 import { showToast, showLoader, hideLoader } from './ui.js';
 
@@ -79,26 +77,12 @@ export async function getAttemptsForUser(options = {}) {
       limitCount = 50
     } = options;
     
-    let q = collection(db, 'attempts');
-    const constraints = [
-      where('userId', '==', authManager.currentUser.uid),
-      orderBy('attemptedAt', 'desc')
-    ];
-    
-    // Add filters
-    if (subject) {
-      constraints.push(where('subject', '==', subject));
-    }
-    
-    // Note: Date range filtering would require composite indexes
-    // For now, we'll filter client-side
-    
-    // Add limit
-    constraints.push(limit(limitCount));
-    
-    // Build query
-    q = query(q, ...constraints);
-    
+    // Query by user ID only to avoid needing composite indexes
+    const q = query(
+      collection(db, 'attempts'),
+      where('userId', '==', authManager.currentUser.uid)
+    );
+
     const querySnapshot = await getDocs(q);
     let attempts = [];
     
@@ -112,6 +96,11 @@ export async function getAttemptsForUser(options = {}) {
       });
     });
     
+    // Client-side subject filtering
+    if (subject) {
+      attempts = attempts.filter(attempt => attempt.subject === subject);
+    }
+
     // Client-side date filtering if needed
     if (startDate || endDate) {
       attempts = attempts.filter(attempt => {
@@ -121,7 +110,11 @@ export async function getAttemptsForUser(options = {}) {
         return true;
       });
     }
-    
+
+    // Sort by date (newest first) and apply limit
+    attempts.sort((a, b) => b.attemptedAt - a.attemptedAt);
+    attempts = attempts.slice(0, limitCount);
+
     return attempts;
   } catch (error) {
     console.error('Error getting attempts:', error);

--- a/subjects.html
+++ b/subjects.html
@@ -164,7 +164,7 @@
 
     <script type="module">
         import { authManager } from './assets/js/auth.js';
-        import { getPublishedPassagesBySubject } from './assets/js/passages.js';
+        import { getPublishedPassagesBySubject, getPassage } from './assets/js/passages.js';
         import { saveAttempt } from './assets/js/attempts.js';
         import { showToast, formatDuration } from './assets/js/ui.js';
 
@@ -254,24 +254,83 @@
         };
 
         // Preview passage
-        window.previewPassage = function(passageId) {
-            // For now, just start the quiz - you could implement a preview mode
-            startQuiz(passageId);
+        window.previewPassage = async function(passageId) {
+            try {
+                const passage = await getPassage(passageId);
+                if (!passage) {
+                    showToast('Passage not found', 'error');
+                    return;
+                }
+
+                let modal = document.getElementById('passage-preview-modal');
+                if (!modal) {
+                    modal = document.createElement('div');
+                    modal.id = 'passage-preview-modal';
+                    modal.className = 'modal';
+                    modal.innerHTML = `
+                        <div class="modal-content" style="max-width: 800px; max-height: 90vh;">
+                            <div class="modal-header">
+                                <h3 id="preview-modal-title"></h3>
+                                <button class="modal-close" onclick="closePreviewModal()">&times;</button>
+                            </div>
+                            <div class="modal-body" style="max-height: 70vh; overflow-y: auto;">
+                                <div id="preview-modal-details" style="margin-bottom: 1rem;"></div>
+                                <div id="preview-modal-text"></div>
+                            </div>
+                        </div>
+                    `;
+                    modal.addEventListener('click', function(e) {
+                        if (e.target === modal) {
+                            closePreviewModal();
+                        }
+                    });
+                    document.body.appendChild(modal);
+                }
+
+                const text = passage.text || passage.content || '';
+                document.getElementById('preview-modal-title').textContent = passage.title || '';
+
+                const diff = passage.difficulty || 'Unknown';
+                document.getElementById('preview-modal-details').innerHTML = `
+                    <span class="difficulty-badge ${diff.toLowerCase()}">${diff}</span>
+                `;
+                document.getElementById('preview-modal-text').textContent = text;
+
+                modal.classList.add('show');
+            } catch (error) {
+                console.error('Error previewing passage:', error);
+                showToast('Failed to load passage', 'error');
+            }
+        };
+
+        window.closePreviewModal = function() {
+            const modal = document.getElementById('passage-preview-modal');
+            if (modal) {
+                modal.classList.remove('show');
+            }
         };
 
         // Start quiz
         window.startQuiz = async function(passageId) {
             try {
-                // Get passage data
-                const passages = await getPublishedPassagesBySubject('Biology'); // This is a simplified approach
-                // In a real implementation, you'd want a getPassage(passageId) function
-                
-                // For now, redirect to a quiz page or implement inline quiz
-                // This is a simplified implementation
-                showToast('Quiz functionality would be implemented here', 'info');
-                
-                // Example of how you might implement an inline quiz:
-                // loadQuizInModal(passageId);
+                const passage = await getPassage(passageId);
+                if (!passage) {
+                    showToast('Passage not found', 'error');
+                    return;
+                }
+
+                const cachedKey = 'studysphere.passages.v1';
+                const passages = JSON.parse(localStorage.getItem(cachedKey) || '[]');
+                const normalized = { ...passage, text: passage.text || passage.content || '' };
+                const index = passages.findIndex(p => p.id === passageId);
+                if (index >= 0) {
+                    passages[index] = normalized;
+                } else {
+                    passages.push(normalized);
+                }
+                localStorage.setItem(cachedKey, JSON.stringify(passages));
+
+                window.location.href = `quiz.html?passage=${passageId}`;
             } catch (error) {
                 console.error('Error starting quiz:', error);
                 showToast('Failed to start quiz', 'error');


### PR DESCRIPTION
## Summary
- Allow admins to specify a time limit and build multiple‑choice questions when creating passages
- Capture questions and timing in the passage payload for persistence
- Display question count and time for each passage in the admin table
- Handle missing difficulty in passage previews to avoid runtime errors
- Query quiz attempts without requiring Firestore composite indexes, preventing quiz history load failures

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba63f1c6f88329ac28baf24db3eef1