### PR TITLE
Sanitize difficulty badge and add auth ready loading state

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1881,3 +1881,26 @@ p {
         transform: rotate(360deg);
     }
 }
+
+/* Auth pending state */
+body.auth-pending .navbar {
+    visibility: hidden;
+}
+
+body.auth-pending::before {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 3px;
+    background: linear-gradient(90deg, #3b82f6, #60a5fa, #3b82f6);
+    background-size: 200% 100%;
+    animation: auth-loading 1.5s linear infinite;
+    z-index: 2000;
+}
+
+@keyframes auth-loading {
+    0% { background-position: 0 0; }
+    100% { background-position: -200% 0; }
+}

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -4,7 +4,7 @@
  */
 
 import { auth, db } from './firebase.js';
-import { 
+import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
   signInWithPopup,
@@ -13,7 +13,11 @@ import {
   sendPasswordResetEmail,
   sendEmailVerification,
   onAuthStateChanged,
-  updateProfile
+  updateProfile,
+  setPersistence,
+  browserSessionPersistence,
+  browserLocalPersistence,
+  getIdTokenResult
 } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js';
 import { 
   doc, 
@@ -29,7 +33,17 @@ class AuthManager {
     this.currentUser = null;
     this.userRole = null;
     this.googleProvider = new GoogleAuthProvider();
+    this._ready = new Promise((resolve) => {
+      this._resolveReady = resolve;
+    });
     this.init();
+  }
+
+  /**
+   * Promise that resolves when auth state and role are ready
+   */
+  ready() {
+    return this._ready;
   }
 
   /**
@@ -52,6 +66,10 @@ class AuthManager {
       }
       
       this.checkAuthRequirement();
+      if (this._resolveReady) {
+        this._resolveReady();
+        this._resolveReady = null;
+      }
     });
   }
 
@@ -60,20 +78,48 @@ class AuthManager {
    */
   async loadUserRole() {
     if (!this.currentUser) return;
-    
+
+    const cacheKey = `userRole:${this.currentUser.uid}`;
+    const cached = localStorage.getItem(cacheKey);
+    const now = Date.now();
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached);
+        if (parsed.expires > now) {
+          this.userRole = parsed.role;
+          return;
+        }
+      } catch {}
+    }
+
     try {
-      const userDoc = await getDoc(doc(db, 'users', this.currentUser.uid));
-      if (userDoc.exists()) {
-        this.userRole = userDoc.data().role || 'student';
-      } else {
-        // Create user document if it doesn't exist
-        await this.createUserDocument();
+      const token = await getIdTokenResult(this.currentUser);
+      if (token.claims?.admin) {
+        this.userRole = 'admin';
+      }
+    } catch (e) {
+      console.error('Error checking custom claims:', e);
+    }
+
+    if (!this.userRole) {
+      try {
+        const userDoc = await getDoc(doc(db, 'users', this.currentUser.uid));
+        if (userDoc.exists()) {
+          this.userRole = userDoc.data().role || 'student';
+        } else {
+          await this.createUserDocument();
+          this.userRole = 'student';
+        }
+      } catch (error) {
+        console.error('Error loading user role:', error);
         this.userRole = 'student';
       }
-    } catch (error) {
-      console.error('Error loading user role:', error);
-      this.userRole = 'student'; // Default fallback
     }
+
+    localStorage.setItem(cacheKey, JSON.stringify({
+      role: this.userRole,
+      expires: now + 10 * 60 * 1000
+    }));
   }
 
   /**
@@ -143,15 +189,13 @@ class AuthManager {
   /**
    * Sign in with email and password
    */
-  async signIn(email, password) {
+  async signIn(email, password, remember) {
     try {
       showLoader('Signing in...');
-      
+      await setPersistence(auth, remember ? browserLocalPersistence : browserSessionPersistence);
       const userCredential = await signInWithEmailAndPassword(auth, email, password);
-      
       hideLoader();
       showToast('Welcome back!', 'success');
-      
       return userCredential.user;
     } catch (error) {
       hideLoader();
@@ -163,15 +207,13 @@ class AuthManager {
   /**
    * Sign in with Google
    */
-  async signInWithGoogle() {
+  async signInWithGoogle(remember) {
     try {
       showLoader('Signing in with Google...');
-      
+      await setPersistence(auth, remember ? browserLocalPersistence : browserSessionPersistence);
       const result = await signInWithPopup(auth, this.googleProvider);
-      
       hideLoader();
       showToast('Welcome!', 'success');
-      
       return result.user;
     } catch (error) {
       hideLoader();
@@ -183,9 +225,13 @@ class AuthManager {
   /**
    * Sign out
    */
-  async signOutUser() {
+  async signOut() {
     try {
+      const uid = this.currentUser?.uid;
       await signOut(auth);
+      if (uid) {
+        localStorage.removeItem(`userRole:${uid}`);
+      }
       showToast('Signed out successfully', 'success');
     } catch (error) {
       this.handleAuthError(error);
@@ -397,7 +443,7 @@ window.toggleUserMenu = function() {
 
 window.signOut = function() {
   if (confirm('Are you sure you want to sign out?')) {
-    authManager.signOutUser();
+    authManager.signOut();
   }
 };
 
@@ -447,9 +493,10 @@ document.addEventListener('DOMContentLoaded', function() {
       
       const email = document.getElementById('signin-email').value;
       const password = document.getElementById('signin-password').value;
-      
+      const remember = document.getElementById('signin-remember')?.checked;
+
       try {
-        await authManager.signIn(email, password);
+        await authManager.signIn(email, password, remember);
         authManager.hideAuthModal();
       } catch (error) {
         // Error already handled in signIn method
@@ -478,7 +525,8 @@ document.addEventListener('DOMContentLoaded', function() {
   googleButtons.forEach(button => {
     button.addEventListener('click', async function() {
       try {
-        await authManager.signInWithGoogle();
+        const remember = document.getElementById('signin-remember')?.checked;
+        await authManager.signInWithGoogle(remember);
         authManager.hideAuthModal();
       } catch (error) {
         // Error already handled in signInWithGoogle method

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="assets/css/styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
-<body>
+<body class="auth-pending">
     <!-- Firebase Config (paste your config here) -->
     <script type="application/json" id="firebase-config">
     {
@@ -164,6 +164,12 @@
                             <label for="signin-password" class="form-label">Password</label>
                             <input type="password" id="signin-password" class="form-input" required>
                         </div>
+                        <div class="form-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" id="signin-remember">
+                                Remember me
+                            </label>
+                        </div>
                         <button type="submit" class="btn btn-primary" style="width: 100%; margin-bottom: 1rem;">Sign In</button>
                     </form>
                     <button class="btn btn-outline google-signin-btn" style="width: 100%; margin-bottom: 1rem;">
@@ -284,6 +290,13 @@
         import { authManager } from './assets/js/auth.js';
         window.authManager = authManager;
         window.showAuthTab = showAuthTab;
+
+        authManager.ready().then(() => {
+            document.body.classList.remove('auth-pending');
+            if (!authManager.isAdmin()) {
+                document.querySelectorAll('.admin-only').forEach(el => el.remove());
+            }
+        });
     </script>
 </body>
 </html>

--- a/subjects.html
+++ b/subjects.html
@@ -289,8 +289,10 @@
 
                 const text = passage.text || passage.content || '';
                 document.getElementById('preview-modal-title').textContent = passage.title || '';
+                const validDiffs = ['easy','medium','hard'];
+                const diff = validDiffs.includes((passage.difficulty || '').toLowerCase()) ? passage.difficulty : 'Unknown';
                 document.getElementById('preview-modal-details').innerHTML = `
-                    <span class="difficulty-badge ${passage.difficulty.toLowerCase()}">${passage.difficulty}</span>
+                    <span class="difficulty-badge ${diff.toLowerCase()}">${diff}</span>
                 `;
                 document.getElementById('preview-modal-text').textContent = text;
 


### PR DESCRIPTION
## Summary
- Validate passage difficulty against an allow list before rendering preview badge
- Expose `authManager.ready()` that waits for auth state and caches role with custom claim support
- Add optional persistent sign-in and a loading-bar `auth-pending` UI

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba768cd4b483299b184d3e9d750210